### PR TITLE
Fix site specific search in GoogleNews & BingNews classes

### DIFF
--- a/feedgen/parsers/bingnews.py
+++ b/feedgen/parsers/bingnews.py
@@ -52,11 +52,8 @@ class BingNews(SearchParser):
         -------
         Python dict() object of the form <name,value>
         """
-        # Setup the search term
-        search_term = self.search_text
-
         # Assemble the sites
         if len(self.sites) > 0:
-            search_term += ' site:' + ('OR site:'.join(self.sites))
+            self.search_text += ' site:' + ('OR site:'.join(self.sites))
 
         return super().get_params()

--- a/feedgen/parsers/googlenews.py
+++ b/feedgen/parsers/googlenews.py
@@ -25,7 +25,7 @@ class GoogleNews(SearchParser):
             container = CSSInnerText('div.NiLAwe'),
             title     = CSSInnerText('h3.ipQwMb'),
             link      = CSSAttribute('a.VDXfz', attr='href'),
-            descrip   = CSSInnerText('span.xBbh9'),
+            descrip   = CSSInnerText('h3.ipQwMb'),
             extras = {
                 'pubDate': CSSAttribute('time.WW6dff', attr='datetime',
                                         default=datetime.datetime.now().isoformat())
@@ -56,12 +56,9 @@ class GoogleNews(SearchParser):
         -------
         Python dict() object of the form <name,value>
         """
-        # Setup the search term
-        search_term = self.search_text
-
         # Assemble the sites
         if len(self.sites) > 0:
-            search_term += ' site:' + ('OR site:'.join(self.sites))
+            self.search_text += ' site:' + ('OR site:'.join(self.sites))
 
         return super().get_params()
 


### PR DESCRIPTION
Fixes site specific search in GoogleNews and BingNews.

The `get_params` methods for GoogleNews and BingNews were creating variables that included the news sites to search, but this parameter wasn't actually being used. This fixes that issue.

Resolves #10 